### PR TITLE
Set mains voltage measurement to whole number only.

### DIFF
--- a/packages/energy.yml
+++ b/packages/energy.yml
@@ -60,7 +60,7 @@ sensor:
     voltage:
       id: bl0940_voltage
       name: 'Voltage'
-      accuracy_decimals: 3
+      accuracy_decimals: 0
     current:
       id: bl0940_current
       name: 'Current'


### PR DESCRIPTION
The mains voltage reading will almost certainly differ each sample when including decimals causing a lot of churn in Home Assistant. The fractional part of ~230v is not that interesting. 